### PR TITLE
Move url context to seperate key if it is not an array

### DIFF
--- a/src/FilebeatContextProcessor.php
+++ b/src/FilebeatContextProcessor.php
@@ -141,6 +141,11 @@ class FilebeatContextProcessor
             $record["context"]["url"] = [];
         }
 
+        if ( ! is_array($record["context"]["url"])) {
+            $record["context"]["context-url"] = $record["context"]["url"];
+            $record["context"]["url"] = [];
+        }
+
         $record["context"]["url"]['path'] = $_SERVER['REQUEST_URI'] ?? null;
         $record["context"]["url"]['method'] = $_SERVER['REQUEST_METHOD'] ?? null;
         $record["context"]["url"]['referer'] = $_SERVER['HTTP_REFERER'] ?? null;

--- a/src/FilebeatContextProcessor.php
+++ b/src/FilebeatContextProcessor.php
@@ -142,8 +142,8 @@ class FilebeatContextProcessor
         }
 
         if ( ! is_array($record["context"]["url"])) {
-            $record["context"]["context-url"] = $record["context"]["url"];
-            $record["context"]["url"] = [];
+            $originalValue = $record["context"]["url"];
+            $record["context"]["url"] = ["original" => $originalValue];
         }
 
         $record["context"]["url"]['path'] = $_SERVER['REQUEST_URI'] ?? null;

--- a/src/FilebeatContextProcessor.php
+++ b/src/FilebeatContextProcessor.php
@@ -142,7 +142,7 @@ class FilebeatContextProcessor
         }
 
         if ( ! is_array($record["context"]["url"])) {
-            $originalValue = $record["context"]["url"];
+            $originalValue = (string)$record["context"]["url"];
             $record["context"]["url"] = ["original" => $originalValue];
         }
 


### PR DESCRIPTION
If trying to log with [`url` => 'https://example.org'] as context the context processor fails with `invalid string offset 'path'` on line 144 and on until trying to assign to `$record["context"]["url"]["headers"]`